### PR TITLE
 Full color palette support

### DIFF
--- a/src/blitter/opengl.c
+++ b/src/blitter/opengl.c
@@ -16,6 +16,15 @@
 
 //#define TEXMIN256
 
+#if !defined(I386_ASM) && !defined(PROCESSOR_ARM)
+#define RGB24_PIXELS 1
+#define PIXEL_TYPE GL_BGRA
+#define PIXEL_SIZE GL_UNSIGNED_BYTE
+#else
+#define PIXEL_TYPE GL_RGB
+#define PIXEL_SIZE GL_UNSIGNED_SHORT_5_6_5
+#endif
+
 static float a;
 static float b;
 static float c;
@@ -141,7 +150,11 @@ blitter_opengl_init()
 		c = (240.0/256.0);
 */
 #ifdef USE_GL2
+#ifndef RGB24_PIXELS
 	    tex_opengl= SDL_CreateRGBSurface(SDL_SWSURFACE, 512, 256, 16, 0xF800, 0x7E0, 0x1F, 0);
+#else
+	    tex_opengl= SDL_CreateRGBSurface(SDL_SWSURFACE, 512, 256, 32, 0, 0, 0, 0);
+#endif
 #else
 	    pglPixelStorei(GL_UNPACK_ROW_LENGTH, 352);
 #endif
@@ -152,10 +165,18 @@ blitter_opengl_init()
 	    b = ((512.0/(float)visible_area.w) - 1.0f)*effect[neffect].x_ratio/2.0;
 	    c = (((float)visible_area.h/256.0))*effect[neffect].y_ratio/2.0;
 	    d = (((float)((visible_area.w<<1)-512)/256.0))*effect[neffect].y_ratio/2.0;
+#ifndef RGB24_PIXELS
 	    screen = SDL_CreateRGBSurface(SDL_SWSURFACE, visible_area.w<<1,  /*visible_area.h<<1*/512, 16, 0xF800, 0x7E0, 0x1F, 0);
+#else
+            screen = SDL_CreateRGBSurface(SDL_SWSURFACE, visible_area.w<<1,  /*visible_area.h<<1*/512, 32, 0, 0, 0, 0);
+#endif
 	    //printf("[opengl] create_screen %p\n",screen);
 #ifdef USE_GL2
+#ifndef RGB24_PIXELS
 	    tex_opengl= SDL_CreateRGBSurface(SDL_SWSURFACE, 1024, 512, 16, 0xF800, 0x7E0, 0x1F, 0);
+#else
+	    tex_opengl= SDL_CreateRGBSurface(SDL_SWSURFACE, 1024, 512, 32, 0, 0, 0, 0);
+#endif
 	    if (visible_area.w==320) {
 		glrectef.x=0;
 		glrectef.y=0;
@@ -200,7 +221,7 @@ blitter_opengl_update()
     if (neffect == 0) {
 #ifndef USE_GL2
 
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, buffer->pixels + (visible_area.x<<1));
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, buffer->pixels + (visible_area.x<<1));
 	pglBegin(GL_QUADS);
 	//pglTexCoord2f(16.0f/256.0f, 16.0f/256.0f);
 	//pglVertex2f	(-1.0f, 1.0f);
@@ -217,7 +238,7 @@ blitter_opengl_update()
 	pglVertex2f	(-1.0f, -1.0f);
 	pglEnd();
 				
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 64, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, buffer->pixels + 512+ (visible_area.x<<1));
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 64, 256, 0, PIXEL_TYPE, PIXEL_SIZE, buffer->pixels + 512+ (visible_area.x<<1));
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 16.0f/256.0f);
 	pglVertex2f	(VALA, 1.0f);
@@ -234,7 +255,7 @@ blitter_opengl_update()
 
 #else
 	SDL_BlitSurface(buffer, &visible_area, tex_opengl, NULL);
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 512, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, tex_opengl->pixels);
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 512, 256, 0, PIXEL_TYPE, PIXEL_SIZE, tex_opengl->pixels);
 
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);
@@ -256,7 +277,7 @@ blitter_opengl_update()
     else
     {		
 #ifndef USE_GL2
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, screen->pixels );
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, screen->pixels );
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);
 	pglVertex2f	(-1.0f, 1.0f);
@@ -271,7 +292,7 @@ blitter_opengl_update()
 	pglVertex2f	(-1.0f, 0.0f);
 	pglEnd();
 		
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, screen->pixels + 512 );
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, screen->pixels + 512 );
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);
 	pglVertex2f	(a, 1.0f);
@@ -286,7 +307,7 @@ blitter_opengl_update()
 	pglVertex2f	(a, 0.0f);
 	pglEnd();
 				
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, screen->pixels + 1024 );
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, screen->pixels + 1024 );
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);
 	pglVertex2f	(b, 1.0f);
@@ -301,7 +322,7 @@ blitter_opengl_update()
 	pglVertex2f	(b, 0.0f);
 	pglEnd();	
 				
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, screen->pixels + (visible_area.w<<2) * 224 );
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, screen->pixels + (visible_area.w<<2) * 224 );
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);
 	pglVertex2f	(-1.0f, 0.0f);
@@ -316,7 +337,7 @@ blitter_opengl_update()
 	pglVertex2f	(-1.0f, -1.0f);
 	pglEnd();
 				
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, screen->pixels + (visible_area.w<<2) * 224 + 512 );
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, screen->pixels + (visible_area.w<<2) * 224 + 512 );
 	pglBegin(GL_QUADS);		
 	pglTexCoord2f(0.0f, 0.0f);
 	pglVertex2f	(a, 0.0f);
@@ -331,7 +352,7 @@ blitter_opengl_update()
 	pglVertex2f	(a, -1.0f);
 	pglEnd();
 		
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, screen->pixels + (visible_area.w<<2) * 224 + 1024 );
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 256, 256, 0, PIXEL_TYPE, PIXEL_SIZE, screen->pixels + (visible_area.w<<2) * 224 + 1024 );
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);
 	pglVertex2f	(b, 0.0f);
@@ -347,7 +368,7 @@ blitter_opengl_update()
 	pglEnd();
 #else
 	SDL_BlitSurface(screen, &glrectef, tex_opengl, NULL);
-	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 1024, 512, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, tex_opengl->pixels);
+	pglTexImage2D(GL_TEXTURE_2D, 0, 3, 1024, 512, 0, PIXEL_TYPE, PIXEL_SIZE, tex_opengl->pixels);
 
 	pglBegin(GL_QUADS);
 	pglTexCoord2f(0.0f, 0.0f);

--- a/src/memory.c
+++ b/src/memory.c
@@ -524,13 +524,22 @@ LONG_STORE(mem68k_store_sram)
 ;
 
 /**** PALETTE ****/
-/*static __inline__ */Uint16 convert_pal(Uint16 npal) {
-    int r = 0, g = 0, b = 0;
+/*static __inline__ */Uint32 convert_pal(Uint16 npal) {
+    int r = 0, g = 0, b = 0, dark = 0;
     r = ((npal >> 7) & 0x1e) | ((npal >> 14) & 0x01);
     g = ((npal >> 3) & 0x1e) | ((npal >> 13) & 0x01);
     b = ((npal << 1) & 0x1e) | ((npal >> 12) & 0x01);
+    dark = ((npal >> 15) & 0x01) ^ 1;
 
+#if !defined(I386_ASM) && !defined(PROCESSOR_ARM)
+    /* 2^6 bits components (neogeo) -> 2^8 bits components (RGB24) */
+    r = (r << 1 | dark) << 2;
+    g = (g << 1 | dark) << 2;
+    b = (b << 1 | dark) << 2;
+    return (r << 16) + (g << 8) + b;
+#else
     return (r << 11) + (g << 6) + b;
+#endif
 }
 
 void update_all_pal(void) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -445,8 +445,12 @@ void init_sdl(void) {
 	exit(-1);
     }
 
+#if !defined(I386_ASM) && !defined(PROCESSOR_ARM)
+    buffer = SDL_CreateRGBSurface(surface_type, 352, 256, 32, 0, 0, 0, 0);
+#else
     buffer = SDL_CreateRGBSurface(surface_type, 352, 256, 16, 0xF800, 0x7E0,
 				  0x1F, 0);
+#endif
     SDL_FillRect(buffer,NULL,SDL_MapRGB(buffer->format,0xE5,0xE5,0xE5));
 
     fontbuf = SDL_CreateRGBSurfaceFrom(font_image.pixel_data, font_image.width, font_image.height

--- a/src/video.c
+++ b/src/video.c
@@ -322,7 +322,7 @@ static __inline__ void draw_fix_char(unsigned char *buf, int start, int end) {
 	unsigned int *gfxdata, myword;
 	int x, y, yy;
 	unsigned char col;
-	unsigned short *br;
+	buffer_pixel_t *br;
 	unsigned int *paldata;
 	unsigned int byte1, byte2;
 	int banked, garouoffsets[32];
@@ -380,7 +380,7 @@ static __inline__ void draw_fix_char(unsigned char *buf, int start, int end) {
 
 			if ((byte1 >= (memory.rom.game_sfix.size >> 5)) || (fix_usage[byte1] == 0x00)) continue;
 
-			br = (unsigned short*) buf + ((y << 3)) * buffer->w + (x << 3) + 16;
+			br = (buffer_pixel_t*) buf + ((y << 3)) * buffer->w + (x << 3) + 16;
 #ifdef PROCESSOR_ARM
 			draw_one_char_arm(byte1, byte2, br);
 #elif I386_ASM

--- a/src/video.h
+++ b/src/video.h
@@ -67,6 +67,16 @@ typedef struct VIDEO {
     GFX_CACHE spr_cache;
 }VIDEO;
 
+#if !defined(I386_ASM) && !defined(PROCESSOR_ARM)
+/* RGBA 32bits per pixel, entire Neo Geo palette (65536 colors) */
+typedef unsigned int buffer_pixel_t;
+#define PIXEL_PITCH (buffer->pitch >> 2)
+#else
+/* optimized ASM for RGB 16bits per pixel, reduced color palette */
+typedef unsigned short buffer_pixel_t;
+#define PIXEL_PITCH (buffer->pitch >> 1)
+#endif
+
 #define RASTER_LINES 261
 
 extern unsigned int neogeo_frame_counter;

--- a/src/video_template.h
+++ b/src/video_template.h
@@ -10,7 +10,7 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
     unsigned int *gfxdata,myword;
     int y;
     unsigned char col;
-    unsigned short *br;
+    buffer_pixel_t *br;
     unsigned int *paldata=(unsigned int *)&current_pc_pal[16*color];
     char *l_y_skip;
     int l; // Line skipping counter
@@ -18,8 +18,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
     int buf_w=544-zx;
     int buf_w_yflip=544+zx;
 #else
-    int buf_w=(buffer->pitch>>1)-zx;
-    int buf_w_yflip=(buffer->pitch>>1)+zx;
+    int pixel_pitch=PIXEL_PITCH;
+    int buf_w=pixel_pitch-zx;
+    int buf_w_yflip=pixel_pitch+zx;
 #endif
     tileno=tileno%memory.nb_of_tiles;
    
@@ -36,9 +37,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
             l=0;
             if (yflip) {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+((zy-1)+sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+((zy-1)+sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
                     gfxdata+=l_y_skip[l]<<1;
@@ -65,15 +66,15 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
 #ifdef DEBUG_VIDEO
                     br-=544;
 #else
-                    br-=(buffer->pitch>>1);
+                    br-=pixel_pitch;
 #endif
                     l++;
                 }
             } else {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+(sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+(sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
                     
@@ -101,7 +102,7 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
 #ifdef DEBUG_VIDEO
                     br+=544;
 #else
-                    br+=(buffer->pitch>>1);
+                    br+=pixel_pitch;
 #endif
                     l++;
 		
@@ -111,9 +112,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
             l=0;
             if (yflip) {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+((zy-1)+sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+((zy-1)+sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
                     gfxdata+=l_y_skip[l]<<1;
@@ -142,14 +143,14 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
 #ifdef DEBUG_VIDEO
                     br-=544;
 #else
-                    br-=(buffer->pitch>>1);
+                    br-=pixel_pitch;
 #endif
                 }
             } else {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+(sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+(sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
                     gfxdata+=l_y_skip[l]<<1;
@@ -178,7 +179,7 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
 #ifdef DEBUG_VIDEO
                     br+=544;
 #else
-                    br+=(buffer->pitch>>1);
+                    br+=pixel_pitch;
 #endif
                 }
             }
@@ -188,9 +189,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
             l=0;
             if (yflip) {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+((zy-1)+sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+((zy-1)+sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
                     gfxdata+=l_y_skip[l]<<1;
@@ -218,9 +219,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
                 }
             } else {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+(sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+(sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
                     gfxdata+=l_y_skip[l]<<1;
@@ -252,9 +253,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
             l=0;
             if (yflip) {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+((zy-1)+sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+((zy-1)+sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+((zy-1)+sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
 
@@ -283,9 +284,9 @@ static __inline__ void RENAME(draw)(unsigned int tileno,int sx,int sy,int zx,int
                 }
             } else {
 #ifdef DEBUG_VIDEO
-                br= (unsigned short *)bmp+(sy)*544+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*544+sx;
 #else
-                br= (unsigned short *)bmp+(sy)*(buffer->pitch>>1)+sx;
+                br= (buffer_pixel_t *)bmp+(sy)*pixel_pitch+sx;
 #endif
                 for(y=0;y<zy;y++) {
 
@@ -322,8 +323,9 @@ static inline void RENAME(draw_scanline)(unsigned int tileno,int yoffs,int sx,in
 {
     unsigned int *gfxdata,myword;
     unsigned char col;
-    unsigned short *br;
+    buffer_pixel_t *br;
     unsigned int *paldata=(unsigned int *)&current_pc_pal[16*color];
+    int pixel_pitch=PIXEL_PITCH;
 
     tileno=tileno%memory.nb_of_tiles;
     gfxdata = (unsigned int *)&memory.rom.tiles.p[ (tileno<<7)];
@@ -335,9 +337,9 @@ static inline void RENAME(draw_scanline)(unsigned int tileno,int yoffs,int sx,in
         if (xflip)
         {
 #ifdef DEBUG_VIDEO
-            br= (unsigned short *)bmp+(line)*(512+32)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*(512+32)+sx;
 #else
-            br= (unsigned short *)bmp+(line)*(buffer->pitch>>1)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*pixel_pitch+sx;
 #endif
 
             myword = gfxdata[1];
@@ -361,9 +363,9 @@ static inline void RENAME(draw_scanline)(unsigned int tileno,int yoffs,int sx,in
             col=(myword>>28)&0xf; if (col) PUTPIXEL(*br,paldata[col]); br++;
         }else {
 #ifdef DEBUG_VIDEO
-            br= (unsigned short *)bmp+(line)*(512+32)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*(512+32)+sx;
 #else
-            br= (unsigned short *)bmp+(line)*(buffer->pitch>>1)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*pixel_pitch+sx;
 #endif
             myword = gfxdata[0];
             col=(myword>>28)&0xf; if (col) PUTPIXEL(*br,paldata[col]);br++; 
@@ -388,9 +390,9 @@ static inline void RENAME(draw_scanline)(unsigned int tileno,int yoffs,int sx,in
     }else { // zx!=16
         if (xflip) {
 #ifdef DEBUG_VIDEO
-            br= (unsigned short *)bmp+(line)*(512+32)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*(512+32)+sx;
 #else
-            br= (unsigned short *)bmp+(line)*(buffer->pitch>>1)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*pixel_pitch+sx;
 #endif
             myword = gfxdata[1];
             if (dda_x_skip[ 0]) {if  ((col=((myword>>0)&0xf))) PUTPIXEL(*br,paldata[col]);br++;} 
@@ -414,9 +416,9 @@ static inline void RENAME(draw_scanline)(unsigned int tileno,int yoffs,int sx,in
 	  
         }else {
 #ifdef DEBUG_VIDEO
-            br= (unsigned short *)bmp+(line)*(512+32)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*(512+32)+sx;
 #else
-            br= (unsigned short *)bmp+(line)*(buffer->pitch>>1)+sx;
+            br= (buffer_pixel_t *)bmp+(line)*pixel_pitch+sx;
 #endif
 
             myword = gfxdata[0];


### PR DESCRIPTION
Switch GnGeo to 32bits RGB per pixel for SDL surfaces. This allows
accurate representation of all the 65536 colors of the Neo Geo palette,
including the ones that use the shared 'dark bit'.

Ref dciabrin/ngdevkit#7