### PR TITLE
generator68k: fix parallel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ mingw/stdio.h
 *.lib
 *.dll
 
+# build artifacts
+
+*.stamp
+
 # generator68k specific intermediate files
 
 cpu68k-?.c

--- a/src/generator68k/Makefile.am
+++ b/src/generator68k/Makefile.am
@@ -13,8 +13,7 @@ gcc_build_verbose_0 = @echo "  HCC    $@";
 def68k_SOURCES = def68k.c tab68k2.c
 
 def68k.stamp: def68k$(EXEEXT) def68k.def
-	$(AM_V_GEN)./def68k$(EXEEXT) 2>&1 >/dev/null
-	touch def68k.stamp
+	$(AM_V_GEN)./def68k$(EXEEXT) 2>&1 >/dev/null && touch def68k.stamp
 
 def68k-proto.h def68k-funcs.h def68k-iibs.h : def68k.stamp
 
@@ -47,12 +46,13 @@ EXTRA_DIST = def68k.def compile.cg ccg/alpha ccg/asm-i386.h ccg/asm-sparc.h \
              ccg/insns-i386.h ccg/insns-ppc.h ccg/insns-sparc.h
 
 MOSTLYCLEANFILES = ${BUILT_SOURCES}
+CLEANFILES = def68k.stamp gen68k.stamp
 
 def68k.o gen68k.o tab68k2.o : %.o : %.c
 	$(gcc_build_verbose)$(CC_FOR_BUILD) -c $< -o $@ -I .. -I ../.. -I . `sdl2-config --cflags` -Umain -Dmain=main
 
 def68k$(EXEEXT) : def68k.o tab68k2.o
-	$(gcc_build_verbose)$(CC_FOR_BUILD) def68k.o tab68k2.o -o $@ 
+	$(gcc_build_verbose)$(CC_FOR_BUILD) def68k.o tab68k2.o -o $@
 
 gen68k$(EXEEXT) : gen68k.o tab68k2.o
 	$(gcc_build_verbose)$(CC_FOR_BUILD) gen68k.o tab68k2.o -o $@
@@ -68,8 +68,7 @@ CPU_OBJ    = cpu68k-0.o  cpu68k-1.o  cpu68k-2.o  cpu68k-3.o  \
 	     cpu68k-c.o  cpu68k-d.o  cpu68k-e.o  cpu68k-f.o
 
 gen68k.stamp : gen68k$(EXEEXT)
-	$(AM_V_GEN)./gen68k$(EXEEXT) 2>&1 >/dev/null
-	touch gen68k.stamp
+	$(AM_V_GEN)./gen68k$(EXEEXT) 2>&1 >/dev/null &&	touch gen68k.stamp
 
 # use a stamp file so gen68k isnt invoked repeatedly for every file
 $(CPU_SOURCE) : gen68k.stamp

--- a/src/generator68k/Makefile.am
+++ b/src/generator68k/Makefile.am
@@ -1,43 +1,29 @@
 ## Process this file with automake to produce Makefile.in
 
 noinst_PROGRAMS = def68k$(EXEEXT) gen68k$(EXEEXT)
-BUILT_SOURCES = def68k-iibs.h def68k-funcs.h def68k-proto.h \
-                cpu68k-0.c cpu68k-1.c cpu68k-2.c cpu68k-3.c \
-                cpu68k-4.c cpu68k-5.c cpu68k-6.c cpu68k-7.c \
-                cpu68k-8.c cpu68k-9.c cpu68k-a.c cpu68k-b.c \
-                cpu68k-c.c cpu68k-d.c cpu68k-e.c cpu68k-f.c
 
 ## stage one - create iibs, funcs and proto header files from def68k.def
 
-#def68k_SOURCES = def68k.c tab68k.c
 AM_CPPFLAGS = -I../ -I.
-
-#head_SOURCES = def68k-iibs.h def68k-funcs.h def68k-proto.h
-
-## see automake.info section on 'Support for executable extensions'
-
-#head$(EXEEXT):	def68k-iibs.h def68k-funcs.h def68k-proto.h
-
-#def68k-iibs.h:	def68k def68k.def
-#	./def68k
-#def68k-funcs.h:	def68k def68k.def
-#	./def68k
-#def68k-proto.h:	def68k def68k.def
-#	./def68k
 
 gcc_build_verbose = $(gcc_build_verbose_$(V))
 gcc_build_verbose_ = $(gcc_build_verbose_$(AM_DEFAULT_VERBOSITY))
 gcc_build_verbose_0 = @echo "  HCC    $@";
 
-def68k-proto.h def68k-funcs.h def68k-iibs.h : def68k$(EXEEXT) def68k.def
-	$(AM_V_GEN)./def68k$(EXEEXT) 2>&1 >/dev/null
+def68k_SOURCES = def68k.c tab68k2.c
 
-cpu68k.c : def68k-proto.h
+def68k.stamp: def68k$(EXEEXT) def68k.def
+	$(AM_V_GEN)./def68k$(EXEEXT) 2>&1 >/dev/null
+	touch def68k.stamp
+
+def68k-proto.h def68k-funcs.h def68k-iibs.h : def68k.stamp
+
+cpu68k.c gen68k.c : def68k-proto.h def68k-funcs.h def68k-iibs.h
 
 ## stage two - create cpu C files and create library
 
 gen68k_SOURCES = gen68k.c tab68k2.c
-gen68k_DEPENDENCIES = def68k-iibs.h def68k
+gen68k_DEPENDENCIES = def68k-iibs.h def68k-proto.h def68k-funcs.h def68k
 
 noinst_LIBRARIES = libgenerator68k.a
 libgenerator68k_a_SOURCES = cpu68k.c reg68k.c registers.h diss68k.c \
@@ -61,16 +47,7 @@ EXTRA_DIST = def68k.def compile.cg ccg/alpha ccg/asm-i386.h ccg/asm-sparc.h \
              ccg/insns-i386.h ccg/insns-ppc.h ccg/insns-sparc.h
 
 MOSTLYCLEANFILES = ${BUILT_SOURCES}
-# ${head_SOURCES}
 
-#ccg/ccg : ccg/ccg.c
-#	$(COMPILE) -DCCGVERSION="\"1.1\""  ccg/ccg.c -o ccg/ccg
-
-#compile.c : compile.cg ccg/ccg
-#	./ccg/ccg -o compile.c compile.cg
-
-#def68k : def68k.c
-#	gcc def68k.c tab68k.c -o def68k -I .. -I ../.. -I . `sdl-config --cflags`
 def68k.o gen68k.o tab68k2.o : %.o : %.c
 	$(gcc_build_verbose)$(CC_FOR_BUILD) -c $< -o $@ -I .. -I ../.. -I . `sdl2-config --cflags` -Umain -Dmain=main
 
@@ -79,9 +56,6 @@ def68k$(EXEEXT) : def68k.o tab68k2.o
 
 gen68k$(EXEEXT) : gen68k.o tab68k2.o
 	$(gcc_build_verbose)$(CC_FOR_BUILD) gen68k.o tab68k2.o -o $@
-
-#compile.o : compile.c 
-#	$(COMPILE) -c $< -o $@
 
 CPU_SOURCE = cpu68k-0.c  cpu68k-1.c  cpu68k-2.c  cpu68k-3.c  \
 	     cpu68k-4.c  cpu68k-5.c  cpu68k-6.c  cpu68k-7.c  \
@@ -93,74 +67,13 @@ CPU_OBJ    = cpu68k-0.o  cpu68k-1.o  cpu68k-2.o  cpu68k-3.o  \
 	     cpu68k-8.o  cpu68k-9.o  cpu68k-a.o  cpu68k-b.o  \
 	     cpu68k-c.o  cpu68k-d.o  cpu68k-e.o  cpu68k-f.o
 
-$(CPU_SOURCE) : gen68k$(EXEEXT)
+gen68k.stamp : gen68k$(EXEEXT)
 	$(AM_V_GEN)./gen68k$(EXEEXT) 2>&1 >/dev/null
+	touch gen68k.stamp
+
+# use a stamp file so gen68k isnt invoked repeatedly for every file
+$(CPU_SOURCE) : gen68k.stamp
 
 $(CPU_OBJ) : %.o : %.c
 	$(AM_V_CC)$(COMPILE) -c $< -o $@
 
-#cpu68k-0.c:	gen68k
-#	./gen68k
-#cpu68k-1.c:	gen68k
-#	./gen68k
-#cpu68k-2.c:	gen68k
-#	./gen68k
-#cpu68k-3.c:	gen68k
-#	./gen68k
-#cpu68k-4.c:	gen68k
-#	./gen68k
-#cpu68k-5.c:	gen68k
-#	./gen68k
-#cpu68k-6.c:	gen68k
-#	./gen68k
-#cpu68k-7.c:	gen68k
-#	./gen68k
-#cpu68k-8.c:	gen68k
-#	./gen68k
-#cpu68k-9.c:	gen68k
-#	./gen68k
-#cpu68k-a.c:	gen68k
-#	./gen68k
-#cpu68k-b.c:	gen68k
-#	./gen68k
-#cpu68k-c.c:	gen68k
-#	./gen68k
-#cpu68k-d.c:	gen68k
-#	./gen68k
-#cpu68k-e.c:	gen68k
-#	./gen68k
-#cpu68k-f.c:	gen68k
-#	./gen68k
-
-#cpu68k-0.o: cpu68k-0.c
-#	$(COMPILE) -c cpu68k-0.c
-#cpu68k-1.o: cpu68k-1.c
-#	$(COMPILE) -c cpu68k-1.c
-#cpu68k-2.o: cpu68k-2.c
-#	$(COMPILE) -c cpu68k-2.c
-#cpu68k-3.o: cpu68k-3.c
-#	$(COMPILE) -c cpu68k-3.c
-#cpu68k-4.o: cpu68k-4.c
-#	$(COMPILE) -c cpu68k-4.c
-#cpu68k-5.o: cpu68k-5.c
-#	$(COMPILE) -c cpu68k-5.c
-#cpu68k-6.o: cpu68k-6.c
-#	$(COMPILE) -c cpu68k-6.c
-#cpu68k-7.o: cpu68k-7.c
-#	$(COMPILE) -c cpu68k-7.c
-#cpu68k-8.o: cpu68k-8.c
-#	$(COMPILE) -c cpu68k-8.c
-#cpu68k-9.o: cpu68k-9.c
-#	$(COMPILE) -c cpu68k-9.c
-#cpu68k-a.o: cpu68k-a.c
-#	$(COMPILE) -c cpu68k-a.c
-#cpu68k-b.o: cpu68k-b.c
-#	$(COMPILE) -c cpu68k-b.c
-#cpu68k-c.o: cpu68k-c.c
-#	$(COMPILE) -c cpu68k-c.c
-#cpu68k-d.o: cpu68k-d.c
-#	$(COMPILE) -c cpu68k-d.c
-#cpu68k-e.o: cpu68k-e.c
-#	$(COMPILE) -c cpu68k-e.c
-#cpu68k-f.o: cpu68k-f.c
-#	$(COMPILE) -c cpu68k-f.c


### PR DESCRIPTION
fixes dependency chain for generated headers:

```
Making all in generator68k
make[3]: Entering directory `/home/rofl/tmp/gngeo/src/generator68k'
gcc -c def68k.c -o def68k.o -I .. -I ../.. -I . `sdl2-config --cflags` -Umain -Dmain=main
gcc -c tab68k2.c -o tab68k2.o -I .. -I ../.. -I . `sdl2-config --cflags` -Umain -Dmain=main
gcc -c gen68k.c -o gen68k.o -I .. -I ../.. -I . `sdl2-config --cflags` -Umain -Dmain=main
gen68k.c:8:25: fatal error: def68k-iibs.h: No such file or directory
 #include "def68k-iibs.h"
                         ^
```

also use a stamp file for files generated by gen68k so it isn't invoked
once per generated source file, with each process overwriting each others
output.

remake -x output:

```
          Prerequisite `gen68k' is newer than target `cpu68k-0.c'.
          /tmp/gngeo/src/generator68k/Makefile:663      Must remake target `cpu68k-0.c'.
Invoking recipe from Makefile:664 to update target `cpu68k-0.c'.
 ##>>>>>>>>>>>>>>>>>>>>>>>>>>0>>>>>>>>>>>>>>>>>>>>>>>>>>>>
./gen68k 2>&1 >/dev/null
 ##<<<<<<<<<<<<<<<<<<<<<<<<<<0<<<<<<<<<<<<<<<<<<<<<<<<<<<<
        /tmp/gngeo/src/generator68k/Makefile:666        File `cpu68k-1.o' does not exist.
          Prerequisite `gen68k' is newer than target `cpu68k-1.c'.
          /tmp/gngeo/src/generator68k/Makefile:663      Must remake target `cpu68k-1.c'.
Invoking recipe from Makefile:664 to update target `cpu68k-1.c'.
 ##>>>>>>>>>>>>>>>>>>>>>>>>>>0>>>>>>>>>>>>>>>>>>>>>>>>>>>>
./gen68k 2>&1 >/dev/null
```